### PR TITLE
lookup all criteria first

### DIFF
--- a/lib/dfp.js
+++ b/lib/dfp.js
@@ -174,26 +174,29 @@ Dfp.prototype.getCriteriaValues = function(name, keyId) {
   var service = 'CustomTargetingService';
   var method = 'getCustomTargetingValuesByStatement';
 
-  var query = "Where name like '";
-  query += name ;
-  query += "' and customTargetingKeyId like '" ;
-  query += keyId ;
-  query += "'";
+  var storeKey = keyId + ':' + name;
 
-  query = new nodeGoogleDfp.Statement(query);
-
-  return criteriaValueStore.getAsync(name)
+  return criteriaValueStore.getAsync(storeKey)
     .catch(function(e) {
       // not found in store, look up instead
+      var query = "Where name like '";
+      query += name ;
+      query += "' and customTargetingKeyId like '" ;
+      query += keyId ;
+      query += "'";
+      query = new nodeGoogleDfp.Statement(query);
       return ctx.dfpUser.executeAPIFunction(service, method, query)
         .then(function(response) {
-          return response.results[0].id;
-        })
-        .tap(function(id) {
-          return criteriaValueStore.putAsync(name, id)
+          return Bluebird.resolve(response.results)
+            .map(function(results){
+              return criteriaValueStore.putAsync(keyId + ':' + results.name, results.id);
+            })
             .catch(function(e) {
               console.log('locally storing criteria value failed', e.stack);
             });
+        })
+        .then(function() {
+          return criteriaValueStore.getAsync(storeKey);
         })
         .catch(function(e) {
           console.log('getting criteria value failed', e.stack);


### PR DESCRIPTION
@CarsonBanov 

Fixes the error described in #3 by changing the behavior of `getCriteriaValues` in `lib/dfp.js` to:
- Look up a value in the local store.
- If it doesn't find it, query DFP for all the values that match the keyid passed in
- Stores all values in the local store
- Look up the initial value again
